### PR TITLE
Set owner and group for created folders

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -39,13 +39,23 @@
 class nubis_storage {
 }
 
-define nubis::storage {
+define nubis::storage(
+    $user   = 'root',
+    $group  = 'root',
+){
   package { [ "ceph-fs-common", "ceph-common" ]:
     ensure => latest,
   }
 
-  file { ["/data", "/data/$name"]:
+  file { "/data":
     ensure => directory,
+  }
+
+  file { "/data/${name}":
+      ensure  => directory,
+      owner   => $user,
+      group   => $group,
+      require => File['/data'],
   }
 
   file { "/etc/ceph":

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -39,24 +39,13 @@
 class nubis_storage {
 }
 
-define nubis::storage(
-    $user   = 'root',
-    $group  = 'root',
-){
-
+define nubis::storage {
   package { [ "ceph-fs-common", "ceph-common" ]:
     ensure => latest,
   }
 
-  file { '/data':
+  file { ["/data", "/data/$name"]:
     ensure => directory,
-  }
-
-  file { "/data/${name}":
-      ensure  => directory,
-      owner   => $user,
-      group   => $group,
-      require => File['/data'],
   }
 
   file { "/etc/ceph":
@@ -65,11 +54,11 @@ define nubis::storage(
 
   file { "/etc/ceph/ceph.conf":
     require => File["/etc/ceph"],
-    ensure  => present,
-    group   => 0,
-    owner   => 0,
-    mode    => 644,
-    source  => "puppet:///modules/${module_name}/ceph.conf",
+    ensure => present,
+    group => 0,
+    owner => 0,
+    mode => 644,
+    source => "puppet:///modules/${module_name}/ceph.conf",
   }
 
   mount { "/data/$name":
@@ -82,9 +71,9 @@ define nubis::storage(
 
   file { "/etc/nubis.d/ceph":
     ensure => present,
-    group  => 0,
-    owner  => 0,
-    mode   => 755,
+    group => 0,
+    owner => 0,
+    mode => 755,
     source => "puppet:///modules/${module_name}/ceph-startup",
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -39,13 +39,24 @@
 class nubis_storage {
 }
 
-define nubis::storage {
+define nubis::storage(
+    $user   = 'root',
+    $group  = 'root',
+){
+
   package { [ "ceph-fs-common", "ceph-common" ]:
     ensure => latest,
   }
 
-  file { ["/data", "/data/$name"]:
+  file { '/data':
     ensure => directory,
+  }
+
+  file { "/data/${name}":
+      ensure  => directory,
+      owner   => $user,
+      group   => $group,
+      require => File['/data'],
   }
 
   file { "/etc/ceph":
@@ -54,11 +65,11 @@ define nubis::storage {
 
   file { "/etc/ceph/ceph.conf":
     require => File["/etc/ceph"],
-    ensure => present,
-    group => 0,
-    owner => 0,
-    mode => 644,
-    source => "puppet:///modules/${module_name}/ceph.conf",
+    ensure  => present,
+    group   => 0,
+    owner   => 0,
+    mode    => 644,
+    source  => "puppet:///modules/${module_name}/ceph.conf",
   }
 
   mount { "/data/$name":
@@ -71,9 +82,9 @@ define nubis::storage {
 
   file { "/etc/nubis.d/ceph":
     ensure => present,
-    group => 0,
-    owner => 0,
-    mode => 755,
+    group  => 0,
+    owner  => 0,
+    mode   => 755,
     source => "puppet:///modules/${module_name}/ceph-startup",
   }
 }


### PR DESCRIPTION
The app that I'm trying to deploy requires that the storage nodes directory be set to a specific user, by default this module sets it to root. I'm adding 2 parameters into the define so that we can specify the user we want. By default it gets set to root if we just call the define as is, however if we add the user and group parameter the /data/${name} folder actually gets its permission set correctly
