### PR TITLE
Fix the incorrect shebang line on ceph binary scripts to use python26

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -50,6 +50,11 @@ define nubis::storage {
     package { "ceph":
       ensure => latest,
     }
+    # need to fix #! to use python26
+    exec { "fix-ceph-shebang":
+      command => "sed -i -e '1c#!/usr/bin/env python26' /usr/bin/ceph*",
+      require => Package["ceph"],
+    }
   }
 
   file { ["/data", "/data/$name"]:


### PR DESCRIPTION
This is an Amazon Linux issue only, fixes #21
