### PR TITLE
[efs] Add support for EFS as a storage flavor

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -43,11 +43,14 @@ nubis::storage { "gozer":
 class nubis_storage {
 }
 
-define nubis::storage($type="ceph") {
+define nubis::storage($type="ceph", $owner="root", $group="root", $mode="0755" ) {
 
   # Create the mountpoint
   file { ["/data", "/data/$name"]:
     ensure => directory,
+    owner => $owner,
+    group => $group,
+    mode  => $mode,
   }
 
   case $type {
@@ -55,7 +58,11 @@ define nubis::storage($type="ceph") {
       nubis::storage::ceph { "$name": }
     }
     'efs': {
-      nubis::storage::efs { "$name": }
+      nubis::storage::efs { "$name":
+        owner => $owner,
+        group => $group,
+        mode  => $mode,
+      }
     }
     default: {
       fail("Unsupported storage type : '$type'")
@@ -64,7 +71,7 @@ define nubis::storage($type="ceph") {
 
 }
 
-define nubis::storage::efs {
+define nubis::storage::efs($owner, $group, $mode) {
   notice("Using EFS")
   class {'nfs::client':
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -69,7 +69,8 @@ define nubis::storage::efs {
   class {'nfs::client':
   }
 
-  file { "/etc/nubis.d/efs-${name}":
+  # make sure we run right after Consul is up, before confd and others
+  file { "/etc/nubis.d/01-efs-${name}":
     ensure => present,
     group => 0,
     owner => 0,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -44,6 +44,12 @@ class nubis_storage {
 }
 
 define nubis::storage($type="ceph") {
+
+  # Create the mountpoint
+  file { ["/data", "/data/$name"]:
+    ensure => directory,
+  }
+
   case $type {
     'ceph': { 
       nubis::storage::ceph { "$name": }
@@ -89,10 +95,6 @@ define nubis::storage::ceph {
       command => "sed -i -e '1c#!/usr/bin/env python26' /usr/bin/ceph*",
       require => Package["ceph"],
     }
-  }
-
-  file { ["/data", "/data/$name"]:
-    ensure => directory,
   }
 
   file { "/etc/ceph":

--- a/metadata.json
+++ b/metadata.json
@@ -8,5 +8,9 @@
   "project_page": null,
   "issues_url": null,
   "dependencies": [
+    {
+      "name": "echocat/nfs",
+      "version_requirement": "1.5.0"
+    }
   ]
 }

--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "echocat/nfs",
-      "version_requirement": "1.5.0"
+      "version_requirement": "1.8.1"
     }
   ]
 }

--- a/templates/efs-startup
+++ b/templates/efs-startup
@@ -13,7 +13,7 @@ CONSUL_PREFIX="$NUBIS_STACK/$NUBIS_ENVIRONMENT"
 
 EFS_ID=$(consulate kv get $CONSUL_PREFIX/config/storage/$EFS_NAME/fsid)
 
-TARGET="$AVAILABILITY_ZONE.$EFS_ID.$REGION.amazonaws.com"
+TARGET="$AVAILABILITY_ZONE.$EFS_ID.efs.$REGION.amazonaws.com"
 
 echo "Mounting EFS:$EFS_ID on $MOUNTPOINT"
 

--- a/templates/efs-startup
+++ b/templates/efs-startup
@@ -18,3 +18,6 @@ TARGET="$AVAILABILITY_ZONE.$EFS_ID.efs.$REGION.amazonaws.com"
 echo "Mounting EFS:$EFS_ID on $MOUNTPOINT"
 
 mount -t nfs4 -o nfsvers=4.1,rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2 "$TARGET:/" "$MOUNTPOINT"
+
+chown <%= @owner %>:<%= @group %> $MOUNTPOINT
+chmod <%= @mode %> $MOUNTPOINT

--- a/templates/efs-startup
+++ b/templates/efs-startup
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -x
+
+EFS_NAME="<%= @name %>"
+MOUNTPOINT="/data/$EFS_NAME"
+AVAILABILITY_ZONE=$(curl -s http://169.254.169.254/latest/meta-data/placement/availability-zone)
+REGION=$(curl -s http://169.254.169.254/latest/dynamic/instance-identity/document | jq '.region' -r)
+
+EFS_ID="unknown"
+
+TARGET="$AVAILABILITY_ZONE.$EFS_ID.$REGION.amazonaws.com"
+
+echo "Mounting EFS:$EFS_ID on $MOUNTPOINT"
+
+mount -t nfs4 -o nfsvers=4.1,rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2 "$TARGET:/" "$MOUNTPOINT"

--- a/templates/efs-startup
+++ b/templates/efs-startup
@@ -7,7 +7,11 @@ MOUNTPOINT="/data/$EFS_NAME"
 AVAILABILITY_ZONE=$(curl -s http://169.254.169.254/latest/meta-data/placement/availability-zone)
 REGION=$(curl -s http://169.254.169.254/latest/dynamic/instance-identity/document | jq '.region' -r)
 
-EFS_ID="unknown"
+NUBIS_STACK=$(nubis-metadata NUBIS_STACK)
+NUBIS_ENVIRONMENT=$(nubis-metadata NUBIS_ENVIRONMENT)
+CONSUL_PREFIX="$NUBIS_STACK/$NUBIS_ENVIRONMENT"
+
+EFS_ID=$(consulate kv get $CONSUL_PREFIX/config/storage/$EFS_NAME/fsid)
 
 TARGET="$AVAILABILITY_ZONE.$EFS_ID.$REGION.amazonaws.com"
 

--- a/templates/efs-startup
+++ b/templates/efs-startup
@@ -11,7 +11,7 @@ NUBIS_STACK=$(nubis-metadata NUBIS_STACK)
 NUBIS_ENVIRONMENT=$(nubis-metadata NUBIS_ENVIRONMENT)
 CONSUL_PREFIX="$NUBIS_STACK/$NUBIS_ENVIRONMENT"
 
-EFS_ID=$(consulate kv get $CONSUL_PREFIX/config/storage/$EFS_NAME/fsid)
+EFS_ID=$(consulate kv get "$CONSUL_PREFIX/config/storage/$EFS_NAME/fsid")
 
 TARGET="$AVAILABILITY_ZONE.$EFS_ID.efs.$REGION.amazonaws.com"
 
@@ -19,5 +19,5 @@ echo "Mounting EFS:$EFS_ID on $MOUNTPOINT"
 
 mount -t nfs4 -o nfsvers=4.1,rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2 "$TARGET:/" "$MOUNTPOINT"
 
-chown <%= @owner %>:<%= @group %> $MOUNTPOINT
-chmod <%= @mode %> $MOUNTPOINT
+chown "<%= @owner %>:<%= @group %>" "$MOUNTPOINT"
+chmod "<%= @mode %>" "$MOUNTPOINT"


### PR DESCRIPTION
Sample usage:

``` puppet
include nubis_storage

nubis::storage { "$project_name":
  type => 'efs',
  owner => 'www-data',
  group => 'www-data',
  mode => '0750',
}
```
